### PR TITLE
updateRecord.Value was missing in ddns updateRecord

### DIFF
--- a/pkg/dns/hetzner.go
+++ b/pkg/dns/hetzner.go
@@ -203,5 +203,6 @@ func (h Hetzner) UpdateZoneRecord(zone Zone, record Record) (Record, error) {
 		Id:     hetznerUpdateResponse.Record.Id,
 		Type:   hetznerUpdateResponse.Record.Type,
 		ZoneId: hetznerUpdateResponse.Record.ZoneId,
+		Value:  hetznerUpdateResponse.Record.Value,
 	}, nil
 }


### PR DESCRIPTION
run() is referencing updateRecord.Value which wasn't exported Hetzner.UpdateZoneRecord yet