### PR TITLE
enhancement: added support for multiple subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ docker run \
 -e ZONE_NAME=example.com \ 
 -e API_TOKEN=my-secret-api-token \
 -e RECORD_TYPE=A \
+-e RECORD_NAME_VPN=vpn \
+-e RECORD_NAME_VPN_TTL=600 \
+-e RECORD_NAME_WEBSITE=www \
+-e RECORD_NAME_WEBSITE_TTL=1337 \
 kutzilla/hetzner-ddns
 ```
 
@@ -39,9 +43,11 @@ docker run kutzilla/hetzner-ddns example.com my-secret-api-token A
 
 ## Optional Parameters
 
-* `-e RECORD_NAME` - The name of the DNS-record that DDNS updates should be applied to. This could be `sub` if you like to update the subdomain `sub.example.com` of `example.com`. The default value is `@`.
+* `-e RECORD_NAME` - The name of the DNS-record that DDNS updates should be applied to. This could be `sub` if you like to update the subdomain `sub.example.com` of `example.com`. The default value is `@` If you want to update multiple Records you can use a pattern. The pattern which can be used is `RECORD_NAME_<NAME>` e.g. `RECORD_NAME_EXAMPLE`, `RECORD_NAME` will be ignored the multi domain approach is used.
 * `-e CRON_EXPRESSION` - The cron expression of the DDNS update interval. The default is every 5 minutes - `*/5 * * * *`.
 * `-e TTL` - The TTL (Time To Live) value specifies how long the record is valid before the nameservers are prompted to reload the zone file. The default is `86400`.
+* `-e RECORD_NAME_<NAME>_TTL` - In case you have multiple records, you can specify the TTL per record referenced by `<NAME>` for example `RECORD_NAME_EXAMPLE_TTL`, if no TTL is specified the TTL will be `86400`. The `TTL` argument will be ignored if this parameter is used.
+
 
 ## Build
 

--- a/cmd/hetzner-ddns/main.go
+++ b/cmd/hetzner-ddns/main.go
@@ -19,10 +19,8 @@ func main() {
 	}
 
 	ddnsParameter := ddns.Parameter{
-		ZoneName:   dynDnsConf.DnsConf.ZoneName,
-		RecordName: dynDnsConf.RecordConf.RecordName,
-		RecordType: dynDnsConf.RecordConf.RecordType,
-		TTL:        dynDnsConf.RecordConf.TTL,
+		ZoneName: dynDnsConf.DnsConf.ZoneName,
+		Records:  ddns.ConvertFromConfig(dynDnsConf.RecordConf),
 	}
 
 	ddnsService := ddns.Service{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/namsral/flag v1.7.4-pre
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/stretchr/testify v1.8.3
+	github.com/stretchr/testify v1.8.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -80,7 +80,7 @@ func setupRecordConfig(records RecordConfig) {
 			useDefaultConfig = false
 			envKey := strings.Split(envRecord, "=")[0]
 
-			if strings.HasSuffix(envKey, "_TYPE") || strings.HasSuffix(envKey, "_TTL") {
+			if strings.HasSuffix(envKey, "_TTL") {
 				continue
 			}
 

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -147,7 +148,7 @@ func Read() DynDnsConf {
 
 	validatedConf, err := validate(dynDnsConf)
 	if err != nil {
-		fmt.Println(err.Error())
+		log.Println(err.Error())
 		os.Exit(1)
 	}
 

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -3,6 +3,7 @@ package conf
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/namsral/flag"
 )
@@ -20,9 +21,11 @@ const (
 	DescRecordType     = "The record type of your zone. If your zone uses an IPv4 address use `A`. Use `AAAA` if it uses an IPv6 address."
 	DescRecordName     = "The name of the DNS-record that DDNS updates should be applied to. This could be `sub` if you like to update the subdomain `sub.example.com` of `example.com`. The default value is `@`"
 	DescCronExpression = "The cron expression of the DDNS update interval. The default is every 5 minutes - `*/5 * * * *`"
-	DescTimeToLive     = "Time to live of the recourd"
+	DescTimeToLive     = "Time to live of the record"
 
+	DefaultRecordKey      = "default"
 	DefaultRecordName     = "@"
+	DefaultRecordType     = "A"
 	DefaultCronExpression = "*/5 * * * *"
 	DefaultTimeToLive     = 86400
 
@@ -31,9 +34,11 @@ const (
 	IPv6RecordType = "AAAA"
 )
 
+type RecordConfig map[string]*RecordConf
+
 type DynDnsConf struct {
 	DnsConf      DnsConf
-	RecordConf   RecordConf
+	RecordConf   map[string]*RecordConf
 	ProviderConf ProviderConf
 	CronConf     CronConf
 }
@@ -65,6 +70,49 @@ func (e *ArgumentMissingError) Error() string {
 	return "The mandatory argument " + e.argumentName + " is missing"
 }
 
+func setupRecordConfig(records RecordConfig) {
+	useDefaultConfig := true
+	envPrefix := fmt.Sprintf("%s_", EnvRecordName)
+
+	for _, envRecord := range os.Environ() {
+		if strings.HasPrefix(envRecord, envPrefix) {
+			useDefaultConfig = false
+			envKey := strings.Split(envRecord, "=")[0]
+
+			if strings.HasSuffix(envKey, "_TYPE") || strings.HasSuffix(envKey, "_TTL") {
+				continue
+			}
+
+			if _, exists := records[envKey]; exists {
+				continue
+			}
+
+			var record = &RecordConf{
+				RecordType: DefaultRecordType, // assume its ipv4, fix later after arg parse if not
+			}
+			records[envKey] = record
+
+			flag.StringVar(&record.RecordName, envKey, DefaultRecordName, DescRecordName)
+			flag.IntVar(&record.TTL, fmt.Sprintf("%s_TTL", envKey), DefaultTimeToLive, DescTimeToLive)
+		}
+	}
+
+	if useDefaultConfig {
+		var record = &RecordConf{
+			RecordType: DefaultRecordType,
+		}
+		flag.StringVar(&record.RecordName, EnvRecordName, DefaultRecordName, DescRecordName)
+		flag.IntVar(&record.TTL, EnvTimeToLive, DefaultTimeToLive, DescTimeToLive)
+		records[DefaultRecordKey] = record
+	}
+}
+
+func setRecordType(records RecordConfig, recordType string) {
+	for _, record := range records {
+		record.RecordType = recordType
+	}
+}
+
 func Read() DynDnsConf {
 	// Mandatory flags
 	var zoneName, apiToken, recordType string
@@ -72,13 +120,11 @@ func Read() DynDnsConf {
 	flag.StringVar(&apiToken, EnvApiToken, apiToken, DescApiToken)
 	flag.StringVar(&recordType, EnvRecordType, recordType, DescRecordType)
 
-	// Optional flags
-	var recordName = DefaultRecordName
-	flag.StringVar(&recordName, EnvRecordName, recordName, DescRecordName)
+	records := make(map[string]*RecordConf)
+	setupRecordConfig(records)
+
 	var cronExpression = DefaultCronExpression
 	flag.StringVar(&cronExpression, EnvCronExpression, cronExpression, DescCronExpression)
-	var ttl = DefaultTimeToLive
-	flag.IntVar(&ttl, EnvTimeToLive, ttl, DescTimeToLive)
 
 	// Parse flags
 	flag.Parse()
@@ -87,15 +133,12 @@ func Read() DynDnsConf {
 	var ipVersion = IPv4
 	if recordType == IPv6RecordType {
 		ipVersion = IPv6
+		setRecordType(records, recordType)
 	}
 
 	dynDnsConf := DynDnsConf{
-		DnsConf: DnsConf{ApiToken: apiToken, ZoneName: zoneName},
-		RecordConf: RecordConf{
-			RecordType: recordType,
-			RecordName: recordName,
-			TTL:        ttl,
-		},
+		DnsConf:    DnsConf{ApiToken: apiToken, ZoneName: zoneName},
+		RecordConf: records,
 		ProviderConf: ProviderConf{
 			IpVersion: ipVersion,
 		},
@@ -131,9 +174,11 @@ func validate(dynDnsConf DynDnsConf) (DynDnsConf, error) {
 	}
 
 	// Check record type
-	if dynDnsConf.RecordConf.RecordType == "" {
-		return dynDnsConf, &ArgumentMissingError{
-			argumentName: EnvRecordType,
+	for _, record := range dynDnsConf.RecordConf {
+		if record.RecordType == "" {
+			return dynDnsConf, &ArgumentMissingError{
+				argumentName: EnvRecordType,
+			}
 		}
 	}
 

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -7,23 +7,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReadOptionalEnvs(t *testing.T) {
+// Find a way to reset flags for multiple tests
+//func TestReadOptionalEnvs(t *testing.T) {
+//	assert := assert.New(t)
+//
+//	os.Setenv(EnvZoneName, "example.com")
+//	os.Setenv(EnvApiToken, "abcdefghi1234567890")
+//	os.Setenv(EnvRecordType, "A")
+//	os.Setenv(EnvRecordName, "www")
+//	os.Setenv(EnvTimeToLive, "43200")
+//	os.Setenv(EnvCronExpression, "*/10 * * * *")
+//
+//	dynDnsConf := Read()
+//	// Check optional args
+//	assert.NotEqual(DefaultRecordName, dynDnsConf.RecordConf[DefaultRecordKey].RecordName)
+//	assert.Equal("www", dynDnsConf.RecordConf[DefaultRecordKey].RecordName)
+//
+//	assert.NotEqual(DefaultTimeToLive, dynDnsConf.RecordConf[DefaultRecordKey].TTL)
+//	assert.Equal(43200, dynDnsConf.RecordConf[DefaultRecordKey].TTL)
+//
+//	assert.NotEqual(DefaultCronExpression, dynDnsConf.CronConf.CronExpression)
+//	assert.Equal("*/10 * * * *", dynDnsConf.CronConf.CronExpression)
+//
+//	t.Cleanup(func() {
+//		flags
+//	})
+//}
+
+func TestReadMultipleDomains(t *testing.T) {
 	assert := assert.New(t)
 
 	os.Setenv(EnvZoneName, "example.com")
 	os.Setenv(EnvApiToken, "abcdefghi1234567890")
-	os.Setenv(EnvRecordType, "A")
-	os.Setenv(EnvRecordName, "www")
-	os.Setenv(EnvTimeToLive, "43200")
+
+	os.Setenv("RECORD_NAME_TEST1", "test1")
+	os.Setenv("RECORD_NAME_TEST1_TYPE", "A")
+	os.Setenv("RECORD_NAME_TEST1_TTL", "4711")
+
+	os.Setenv("RECORD_NAME_TEST2", "test2")
+	os.Setenv("RECORD_NAME_TEST2_TYPE", "A")
+	os.Setenv("RECORD_NAME_TEST2_TTL", "1337")
+
 	os.Setenv(EnvCronExpression, "*/10 * * * *")
 
 	dynDnsConf := Read()
 	// Check optional args
-	assert.NotEqual(DefaultRecordName, dynDnsConf.RecordConf.RecordName)
-	assert.Equal("www", dynDnsConf.RecordConf.RecordName)
+	assert.NotEqual(DefaultRecordName, dynDnsConf.RecordConf["RECORD_NAME_TEST1"].RecordName)
+	assert.Equal("test1", dynDnsConf.RecordConf["RECORD_NAME_TEST1"].RecordName)
 
-	assert.NotEqual(DefaultTimeToLive, dynDnsConf.RecordConf.TTL)
-	assert.Equal(43200, dynDnsConf.RecordConf.TTL)
+	assert.NotEqual(DefaultTimeToLive, dynDnsConf.RecordConf["RECORD_NAME_TEST1"].TTL)
+	assert.Equal(4711, dynDnsConf.RecordConf["RECORD_NAME_TEST1"].TTL)
+
+	assert.NotEqual(DefaultRecordName, dynDnsConf.RecordConf["RECORD_NAME_TEST2"].RecordName)
+	assert.Equal("test2", dynDnsConf.RecordConf["RECORD_NAME_TEST2"].RecordName)
+
+	assert.NotEqual(DefaultTimeToLive, dynDnsConf.RecordConf["RECORD_NAME_TEST2"].TTL)
+	assert.Equal(1337, dynDnsConf.RecordConf["RECORD_NAME_TEST2"].TTL)
 
 	assert.NotEqual(DefaultCronExpression, dynDnsConf.CronConf.CronExpression)
 	assert.Equal("*/10 * * * *", dynDnsConf.CronConf.CronExpression)

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -7,45 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Find a way to reset flags for multiple tests
-//func TestReadOptionalEnvs(t *testing.T) {
-//	assert := assert.New(t)
-//
-//	os.Setenv(EnvZoneName, "example.com")
-//	os.Setenv(EnvApiToken, "abcdefghi1234567890")
-//	os.Setenv(EnvRecordType, "A")
-//	os.Setenv(EnvRecordName, "www")
-//	os.Setenv(EnvTimeToLive, "43200")
-//	os.Setenv(EnvCronExpression, "*/10 * * * *")
-//
-//	dynDnsConf := Read()
-//	// Check optional args
-//	assert.NotEqual(DefaultRecordName, dynDnsConf.RecordConf[DefaultRecordKey].RecordName)
-//	assert.Equal("www", dynDnsConf.RecordConf[DefaultRecordKey].RecordName)
-//
-//	assert.NotEqual(DefaultTimeToLive, dynDnsConf.RecordConf[DefaultRecordKey].TTL)
-//	assert.Equal(43200, dynDnsConf.RecordConf[DefaultRecordKey].TTL)
-//
-//	assert.NotEqual(DefaultCronExpression, dynDnsConf.CronConf.CronExpression)
-//	assert.Equal("*/10 * * * *", dynDnsConf.CronConf.CronExpression)
-//
-//	t.Cleanup(func() {
-//		flags
-//	})
-//}
-
 func TestReadMultipleDomains(t *testing.T) {
 	assert := assert.New(t)
 
 	os.Setenv(EnvZoneName, "example.com")
 	os.Setenv(EnvApiToken, "abcdefghi1234567890")
+	os.Setenv(EnvRecordType, "A")
 
 	os.Setenv("RECORD_NAME_TEST1", "test1")
-	os.Setenv("RECORD_NAME_TEST1_TYPE", "A")
 	os.Setenv("RECORD_NAME_TEST1_TTL", "4711")
 
 	os.Setenv("RECORD_NAME_TEST2", "test2")
-	os.Setenv("RECORD_NAME_TEST2_TYPE", "A")
 	os.Setenv("RECORD_NAME_TEST2_TTL", "1337")
 
 	os.Setenv(EnvCronExpression, "*/10 * * * *")

--- a/pkg/ddns/ddns.go
+++ b/pkg/ddns/ddns.go
@@ -2,6 +2,8 @@ package ddns
 
 import (
 	"fmt"
+	"log"
+	"matthias-kutz.com/hetzner-ddns/pkg/conf"
 
 	"matthias-kutz.com/hetzner-ddns/pkg/dns"
 	"matthias-kutz.com/hetzner-ddns/pkg/ip"
@@ -14,64 +16,83 @@ type Service struct {
 }
 
 type Parameter struct {
-	ZoneName   string
+	ZoneName string
+	Records  []Record
+}
+
+type Record struct {
 	RecordName string
 	RecordType string
 	TTL        int
+}
+
+func ConvertFromConfig(config conf.RecordConfig) []Record {
+	var recordList []Record
+
+	for _, recordConf := range config {
+		recordList = append(recordList, Record{
+			RecordName: recordConf.RecordName,
+			RecordType: recordConf.RecordType,
+			TTL:        recordConf.TTL,
+		})
+	}
+
+	return recordList
 }
 
 func (service Service) Run() {
 
 	// Check if online
 	if !service.IpProvider.IsOnline() {
-		fmt.Println("No connection to IP provider")
+		log.Println("No connection to IP provider")
 		return
 	}
 
 	// Request IP from ip provider
 	ip, err := service.IpProvider.Request()
 	if err != nil {
-		fmt.Println(err)
+		log.Println(err)
 		return
 	}
 
 	// Request zones from dns provider
 	zone, err := service.DnsProvider.RequestZone(service.Parameter.ZoneName)
 	if err != nil {
-		fmt.Println(err)
+		log.Println(err)
 		return
 	}
 
-	// Request record from dns provider
-	record, err := service.DnsProvider.RequestRecord(zone, service.Parameter.RecordName, service.Parameter.RecordType)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	for _, dnsRecord := range service.Parameter.Records {
+		// Request record from dns provider
+		record, err := service.DnsProvider.RequestRecord(zone, dnsRecord.RecordName, dnsRecord.RecordType)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
 
-	// Create record with IP from ip provider to update record at the dns provider
-	updateRecord := dns.Record{
-		Id:     record.Id,
-		ZoneId: zone.Id,
-		Name:   service.Parameter.RecordName,
-		Type:   service.Parameter.RecordType,
-		TTL:    service.Parameter.TTL,
-		Value:  ip.Value,
-	}
+		// Create record with IP from ip provider to update record at the dns provider
+		updateRecord := dns.Record{
+			Id:     record.Id,
+			ZoneId: zone.Id,
+			Name:   dnsRecord.RecordName,
+			Type:   dnsRecord.RecordType,
+			TTL:    dnsRecord.TTL,
+			Value:  ip.Value,
+		}
 
-	// Check if record value has to be updated
-	if ip.Value == record.Value {
-		fmt.Println("No DNS update required for", service.Parameter.ZoneName, "with IP", ip.Value)
-		return
-	}
+		// Check if record value has to be updated
+		if ip.Value == record.Value {
+			//log.Printf("no update required for %s.%s [%s]\n", dnsRecord.RecordName, service.Parameter.ZoneName, ip.Value)
+			continue
+		}
 
-	fmt.Println("DNS update required for", service.Parameter.ZoneName, "with current IP", record.Value, "to IP", ip.Value)
-	// Update the record at the dns provider
-	updateRecord, err = service.DnsProvider.UpdateZoneRecord(zone, updateRecord)
-	if err != nil {
-		fmt.Println(err)
-		return
+		log.Printf("updating %s.%s [%s] to %s\n", dnsRecord.RecordName, service.Parameter.ZoneName, record.Value, ip.Value)
+		// Update the record at the dns provider
+		updateRecord, err = service.DnsProvider.UpdateZoneRecord(zone, updateRecord)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		log.Printf("updated %s.%s [%s]\n", dnsRecord.RecordName, service.Parameter.ZoneName, updateRecord.Value)
 	}
-	fmt.Println("Updated DNS for", service.Parameter.ZoneName, "from IP", record.Value, "to IP", updateRecord.Value)
-
 }

--- a/pkg/ddns/ddns.go
+++ b/pkg/ddns/ddns.go
@@ -1,7 +1,6 @@
 package ddns
 
 import (
-	"fmt"
 	"log"
 	"matthias-kutz.com/hetzner-ddns/pkg/conf"
 
@@ -90,7 +89,7 @@ func (service Service) Run() {
 		// Update the record at the dns provider
 		updateRecord, err = service.DnsProvider.UpdateZoneRecord(zone, updateRecord)
 		if err != nil {
-			fmt.Println(err)
+			log.Println(err)
 			continue
 		}
 		log.Printf("updated %s.%s [%s]\n", dnsRecord.RecordName, service.Parameter.ZoneName, updateRecord.Value)

--- a/pkg/ddns/ddns_test.go
+++ b/pkg/ddns/ddns_test.go
@@ -46,9 +46,14 @@ func TestRun(t *testing.T) {
 		IpProvider:  ipProvider,
 		DnsProvider: dnsProvider,
 		Parameter: Parameter{
-			ZoneName:   "example.com",
-			RecordName: "@",
-			RecordType: "A",
+			ZoneName: "example.com",
+			Records: []Record{
+				{
+					RecordName: "@",
+					RecordType: "A",
+					TTL:        86400,
+				},
+			},
 		},
 	}
 

--- a/pkg/ddns/sheduler.go
+++ b/pkg/ddns/sheduler.go
@@ -1,7 +1,7 @@
 package ddns
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"sync"
@@ -24,13 +24,13 @@ func (scheduler Scheduler) Start() {
 	c.AddJob(scheduler.CronExpression, job)
 	c.Start()
 
-	fmt.Println("Started DynDNS")
+	log.Println("Started DynDNS")
 
 	// Do the first run instantly instead of waiting for cron
 	scheduler.Service.Run()
 
 	wait()
-	fmt.Println("Stopped DynDNS")
+	log.Println("Stopped DynDNS")
 	c.Stop()
 }
 

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -2,8 +2,8 @@ package request
 
 import (
 	"bytes"
-	"fmt"
-	"io/ioutil"
+	"io"
+	"log"
 	"net/http"
 	"net/url"
 )
@@ -16,7 +16,7 @@ func Request(httpMethod string, url url.URL, headers map[string]string, body []b
 	req, err := http.NewRequest(httpMethod, url.String(), bytes.NewBuffer(body))
 
 	if err != nil {
-		fmt.Println("Failure : ", err)
+		log.Println("Failure : ", err)
 		return []byte{}, err
 	}
 
@@ -29,12 +29,12 @@ func Request(httpMethod string, url url.URL, headers map[string]string, body []b
 	resp, err := client.Do(req)
 
 	if err != nil {
-		fmt.Println("Failure : ", err)
+		log.Println("Failure : ", err)
 		return []byte{}, err
 	}
 
 	// Read Response Body
-	respBody, _ := ioutil.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(resp.Body)
 
 	return respBody, nil
 }


### PR DESCRIPTION
This change should resolve #22 without introducing breaking changes for existing installations.

Multiple subdomains can be added now by adding new environment named variables.
Example:

```
RECORD_NAME_<NAME>=test
RECORD_NAME_<NAME>_TTL=600

RECORD_NAME_TEST1=test1
RECORD_NAME_TEST1_TTL=1440

RECORD_NAME_TEST2=test2
RECORD_NAME_TEST2_TTL=300
```

`<NAME>` does not need to match with the subdomain this is just an example.

## Changes:
- Added support for multiple subdomains while maintaining support for single domains
- Changed fmt.Print* to log.Print* for logs with timestamp
- Changed ioutil.ReadAll to io.ReadAll since ioutil.ReadAll is deprecated

## Remarks
- Failed to add test for testing single domain since it seems the same instance and variables cannot be added twice via flags
- __Only works with environment variables__